### PR TITLE
set frame rate at the end of setup() to avoid timeout

### DIFF
--- a/thisisonescene/thisisonescene.pde
+++ b/thisisonescene/thisisonescene.pde
@@ -97,10 +97,6 @@ void settings() {
  * Load all assets in the demo
  */
 void setup() {
-  int fps = 60;
-  // Assembly has 60Hz maximum projector framerate, ref. https://www.assembly.org/summer19/demoscene/rules
-  frameRate(fps);
-
   // Loads 3D mesh. OBJ format can be created with, for example, Blender 3D program: https://www.blender.org/
   gear = loadShape("gear.obj");
   asmLogo = loadShape("assylogo.obj");
@@ -127,6 +123,11 @@ void setup() {
   int rowsPerBeat = 4; // How many rows one beat consists of in the sync editor (GNURocket or so)
   moonlander = Moonlander.initWithSoundtrack(this, "20190608_graffathon_onescene.mp3", bpm, rowsPerBeat);
   moonlander.start();
+
+  // frameRate() triggers drawing stuff, so do it at the end to avoid getting stuck
+  int fps = 60;
+  // Assembly has 60Hz maximum projector framerate, ref. https://www.assembly.org/summer19/demoscene/rules
+  frameRate(fps);
 }
 
 


### PR DESCRIPTION
Prevent a (presumably) rendering-related timeout by moving the
frameRate() call to the very end of setup(), after all the
time-consuming resource loading has finished. The call seems to start a
rendering thread that times out in five seconds.

If the setup function takes a long time after frameRate() (like on my
ancient laptop), this happens:

java.lang.RuntimeException: Waited 5000ms for: <b788508, 5bf6a17>[count 2, qsz 0, owner <main-FPSAWTAnimator#00-Timer0>] - <main-FPSAWTAnimator#00-Timer0-FPSAWTAnimator#00-Timer1>
	at processing.opengl.PSurfaceJOGL$2.run(PSurfaceJOGL.java:410)
	at java.lang.Thread.run(Thread.java:748)

See https://github.com/processing/processing/issues/4468 and/or just google
around for "Waited 5000ms" for more details. This "FPSAWTAnimator" doesn't seem
to be purely Processing-related:

- https://bugs.freedesktop.org/show_bug.cgi?id=103078
- http://forum.jogamp.org/Where-when-is-it-ok-to-call-setFullscreen-td4032828.html
- https://stackoverflow.com/questions/15817476/avoid-recursivelockimpl01unfairish-lock-runtimeexception-timeout

This appears to be the origin of the message:

https://github.com/sgothel/gluegen/blob/df9ff7f340a5ab4e07efc613f5f264eeae63d4c7/src/java/jogamp/common/util/locks/RecursiveLockImpl01Unfairish.java#L198

.. but the real problem would then be in FPSAWTAnimator, a part of JOGL,
that doesn't handle the timeout.